### PR TITLE
Update rdrand-gen.c

### DIFF
--- a/src/rdrand-gen.c
+++ b/src/rdrand-gen.c
@@ -776,7 +776,7 @@ int load_key_line(
         unsigned int *nonce_len
         ) {
     
-    char c;
+    int c;
     unsigned int i;
     char buf[2*RDRAND_MAX_KEY_LENGTH] = {};
 


### PR DESCRIPTION
Changing variable c from type char to int to resolve these warnings:

[src/rdrand-gen.c:785]: (warning) Storing getc() return value in char variable and then comparing with EOF.

[src/rdrand-gen.c:808]: (warning) Storing getc() return value in char variable and then comparing with EOF.